### PR TITLE
Only use promise based getStats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtcstats",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "types": "rtcstats.d.ts",


### PR DESCRIPTION
This makes every browser use promise based getStats, to get rid of the error on recent versions of Chrome