### PR TITLE
Adds option to reset delta compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtcstats",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "types": "rtcstats.d.ts",

--- a/rtcstats.d.ts
+++ b/rtcstats.d.ts
@@ -48,5 +48,5 @@ declare module "rtcstats" {
      * addIceCandidateOnFailure - string
      */
 
-    export default function anonymous(trace: (method: string, id: string, data: RTCStatsDataType) => void, getStatsIntervalmsec: number, prefixesToWrap: string[]): void;
+    export default function anonymous(trace: (method: string, id: string, data: RTCStatsDataType) => void, getStatsIntervalmsec: number, prefixesToWrap: string[]): { resetDelta: () => void };
 }

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -96,6 +96,8 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
   var peerconnectioncounter = 0;
   var isFirefox = !!window.mozRTCPeerConnection;
   var isEdge = !!window.RTCIceGatherer;
+  var prevById = {};
+  
   prefixesToWrap.forEach(function(prefix) {
     if (!window[prefix + 'RTCPeerConnection']) {
       return;
@@ -166,13 +168,12 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
         trace('ondatachannel', id, [event.channel.id, event.channel.label]);
       });
 
-      var prev = {};
       var getStats = function() {
         pc.getStats(null).then(function(res) {
           var now = map2obj(res);
           var base = JSON.parse(JSON.stringify(now)); // our new prev
-          trace('getstats', id, deltaCompression(prev, now));
-          prev = base;
+          trace('getstats', id, deltaCompression(prevById[id] || {}, now));
+          prevById[id] = base;
         });
       };
       // TODO: do we want one big interval and all peerconnections
@@ -392,4 +393,11 @@ module.exports = function(trace, getStatsInterval, prefixesToWrap) {
     }
   });
   */
+
+  return {
+    resetDelta() {
+      prevById = {};
+    }
+  }
+
 };


### PR DESCRIPTION
This adds a function you can call to reset delta compression. 

If sending the stats to a server, and that connection is temporary broken, stats for new candidate-pairs and streams might be tried sent, but never received. This is a problem when delta compressing, as the new stats finally arriving at server (new connection) might be missing important initial info. By resetting, and possibly buffering, when disconnected, we can make sure we get all the info we need on a reconnect.