### PR TITLE
Switches to Date.now()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtcstats",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "types": "rtcstats.d.ts",

--- a/trace-ws.js
+++ b/trace-ws.js
@@ -6,7 +6,7 @@ module.exports = function(wsURL) {
     //console.log.apply(console, arguments);
     // TODO: drop getStats when not connected?
     var args = Array.prototype.slice.call(arguments);
-    args.push(new Date().getTime());
+    args.push(Date.now());
     if (args[1] instanceof RTCPeerConnection) {
       args[1] = args[1].__rtcStatsId;
     }


### PR DESCRIPTION
Switches to Date.now() as this seems not/less affected by dumb timezone spoofing browser extensions