### PR TITLE
Fix type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whereby.com/rtcstats",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "types": "rtcstats.d.ts",

--- a/rtcstats.d.ts
+++ b/rtcstats.d.ts
@@ -1,52 +1,66 @@
 export type ondatachannelArgs = [number | null | string];
-export type createDataChannelArgs = [string | RTCDataChannelInit | undefined ];
+export type createDataChannelArgs = [string | RTCDataChannelInit | undefined];
 export type createOfferArgs = RTCOfferOptions | undefined;
 export type createAnswerArgs = RTCOfferOptions | undefined;
-export type addIceCandidateArgs = RTCIceCandidateInit | RTCIceCandidate
+export type addIceCandidateArgs = RTCIceCandidateInit | RTCIceCandidate;
 
-export type RTCStatsDataType = RTCConfiguration | RTCIceCandidate | RTCSignalingState | RTCIceConnectionState | RTCIceGatheringState |
-                RTCPeerConnectionState | undefined | ondatachannelArgs | string | RTCOfferOptions | undefined | createOfferArgs |
-                createAnswerArgs | RTCSessionDescriptionInit | addIceCandidateArgs | object;
+export type RTCStatsDataType =
+  | RTCConfiguration
+  | RTCIceCandidate
+  | RTCSignalingState
+  | RTCIceConnectionState
+  | RTCIceGatheringState
+  | RTCPeerConnectionState
+  | ondatachannelArgs
+  | RTCOfferOptions
+  | createOfferArgs
+  | createAnswerArgs
+  | RTCSessionDescriptionInit
+  | addIceCandidateArgs
+  | string
+  | object
+  | undefined;
 
-declare module "rtcstats" {
-    /**
-     * Initializes the logging and statistics callback into the trace method for all noted methods
-     *
-     * @param trace - the Trace function which will be called for statistics that shall be logged
-     * @param getStatsIntervalmsec - the interval in which the statistics will be collected
-     * @param prefixesToWrap - the PeerConnection prefixes, set [""] if using the webrtc adapter
-     *
-     * methods - data object type
-     * create - RTCConfiguration
-     * onicecandidate - RTCIceCandidate
-     * onaddstream - string
-     * ontrack - string
-     * onremovestream - string
-     * onsignalingstatechange - RTCSignalingState
-     * oniceconnectionstatechange - RTCIceConnectionState
-     * icegatheringstatechange - RTCIceGatheringState
-     * connectionstatechange - RTCPeerConnectionState
-     * negotiationneeded - undefined
-     * ondatachannel - ondatachannelArgs
-     * getstats - object (browser dependend)
-     * createDataChannel - createDataChannelArgs
-     * close - undefined
-     * addStream - string
-     * removeStream - string
-     * addTrack - string
-     * removeTrack - string
-     * createOffer - createOfferArgs
-     * createAnswer - createAnswerArgs
-     * setLocalDescription - RTCSessionDescriptionInit
-     * setLocalDescriptionOnSuccess - undefined
-     * setLocalDescriptionOnFailure - string
-     * setRemoteDescription - RTCSessionDescriptionInit
-     * setRemoteDescriptionOnSuccess - undefined
-     * setRemoteDescriptionOnFailure - string
-     * addIceCandidate - addIceCandidateArgs
-     * addIceCandidateOnSuccess - undefined
-     * addIceCandidateOnFailure - string
-     */
-
-    export default function anonymous(trace: (method: string, id: string, data: RTCStatsDataType) => void, getStatsIntervalmsec: number, prefixesToWrap: string[]): { resetDelta: () => void };
-}
+/**
+ * Initializes the logging and statistics callback into the trace method for all noted methods
+ *
+ * @param trace - the Trace function which will be called for statistics that shall be logged
+ * @param getStatsIntervalmsec - the interval in which the statistics will be collected
+ * @param prefixesToWrap - the PeerConnection prefixes, set [""] if using the webrtc adapter
+ *
+ * methods - data object type
+ * create - RTCConfiguration
+ * onicecandidate - RTCIceCandidate
+ * onaddstream - string
+ * ontrack - string
+ * onremovestream - string
+ * onsignalingstatechange - RTCSignalingState
+ * oniceconnectionstatechange - RTCIceConnectionState
+ * icegatheringstatechange - RTCIceGatheringState
+ * connectionstatechange - RTCPeerConnectionState
+ * negotiationneeded - undefined
+ * ondatachannel - ondatachannelArgs
+ * getstats - object (browser dependend)
+ * createDataChannel - createDataChannelArgs
+ * close - undefined
+ * addStream - string
+ * removeStream - string
+ * addTrack - string
+ * removeTrack - string
+ * createOffer - createOfferArgs
+ * createAnswer - createAnswerArgs
+ * setLocalDescription - RTCSessionDescriptionInit
+ * setLocalDescriptionOnSuccess - undefined
+ * setLocalDescriptionOnFailure - string
+ * setRemoteDescription - RTCSessionDescriptionInit
+ * setRemoteDescriptionOnSuccess - undefined
+ * setRemoteDescriptionOnFailure - string
+ * addIceCandidate - addIceCandidateArgs
+ * addIceCandidateOnSuccess - undefined
+ * addIceCandidateOnFailure - string
+ */
+export default function anonymous(
+  trace: (method: string, id: string, data: RTCStatsDataType) => void,
+  getStatsIntervalmsec: number,
+  prefixesToWrap: string[],
+): { resetDelta: () => void };


### PR DESCRIPTION
We changed the name of the package, so the type definition didn't work on the consumer side. This should fix it

```
src/index.ts → dist/index.mjs...
[!] (plugin rpt2) RollupError: There was an error during the build:
  [plugin rpt2] src/webrtc/rtcStatsService.ts:180:15 - error TS2349: This expression is not callable.
  Type 'typeof import("/Users/thomasfrivold/whereby/sdk/node_modules/@whereby.com/rtcstats/rtcstats")' has no call signatures.

180 const stats = rtcstats(
                  ~~~~~~~~

Additionally, handling the error in the 'buildEnd' hook caused the following error:
  [plugin rpt2] src/webrtc/rtcStatsService.ts:180:15 - error TS2349: This expression is not callable.
  Type 'typeof import("/Users/thomasfrivold/whereby/sdk/node_modules/@whereby.com/rtcstats/rtcstats")' has no call signatures.

180 const stats = rtcstats(
                  ~~~~~~~~

src/index.ts
    at Object.getRollupError (/Users/thomasfrivold/whereby/sdk/node_modules/rollup/dist/shared/parseAst.js:285:41)
    at /Users/thomasfrivold/whereby/sdk/node_modules/rollup/dist/shared/rollup.js:23517:51
    at catchUnfinishedHookActions (/Users/thomasfrivold/whereby/sdk/node_modules/rollup/dist/shared/rollup.js:23011:16)
    at rollupInternal (/Users/thomasfrivold/whereby/sdk/node_modules/rollup/dist/shared/rollup.js:23500:5)
    at build (/Users/thomasfrivold/whereby/sdk/node_modules/rollup/dist/bin/rollup:1694:55)
    at runRollup (/Users/thomasfrivold/whereby/sdk/node_modules/rollup/dist/bin/rollup:1830:21)
```